### PR TITLE
Fixed match pattern bug

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "modelsmith"
-version = "0.2.1"
+version = "0.2.2"
 description = "Get Pydantic models and Python types as LLM responses from Google Vertex AI models."
 authors = ["Christo Olivier <mail@christoolivier.com>"]
 maintainers = ["Christo Olivier <mail@christoolivier.com>"]

--- a/src/modelsmith/forge.py
+++ b/src/modelsmith/forge.py
@@ -158,8 +158,9 @@ class Forge(Generic[T]):
             except ValidationError as e:
                 exceptions.append(e)
 
-        # Raise any errors that occurred during the JSON validation
-        if exceptions:
+        # Raise any errors that occurred during the JSON validation if a valid model
+        # was not returned
+        if exceptions and model is None:
             raise CombinedException(exceptions)
 
         return model


### PR DESCRIPTION
Fixed match pattern bug that would result in still raising errors even if a model is returned by one of the match patterns but not the others.